### PR TITLE
AWS Lambdaで実行するようにする

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,32 @@
+name: Lambda Production Deploy
+
+on: [push]
+
+jobs:
+  lambda-cd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.5'
+      - name: Install Poetry
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+      - name: Installing dependencises using poetry
+        run: poetry install --no-dev
+      - name: Build Project
+        run: |
+          poetry build
+          poetry run pip install --upgrade -t package dist/*.whl
+          zip -r artifact.zip package -x '*.pyc'
+      - name: Deploy
+      - run: pip3 install awscli
+      - run: aws lambda update-function-code --function-name mastodon-gensokyo-night-prd --zip-file fileb://artifact.zip --publish
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PRD }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PRD }}
+          AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   lambda-cd:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -23,10 +24,11 @@ jobs:
           poetry build
           poetry run pip install --upgrade -t package dist/*.whl
           zip -r artifact.zip package -x '*.pyc'
-      - name: Deploy
-      - run: pip3 install awscli
-      - run: aws lambda update-function-code --function-name mastodon-gensokyo-night-prd --zip-file fileb://artifact.zip --publish
+      - name: Production Deploy
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PRD }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PRD }}
           AWS_DEFAULT_REGION: us-east-1
+        run: |
+          pip3 install awscli
+          aws lambda update-function-code --function-name mastodon-gensokyo-night-prd --zip-file fileb://artifact.zip --publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = ""
 authors = ["kelvin27315 <seven_units@yahoo.co.jp>"]
 license = "MIT"
+packages = [
+  { include = "gensokyo_night"}
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
GitHub Actions の on: schedule にて Post CI を定期的に実行して投稿するようにしているが、これはリポジトリに60日間活動が認められない場合停止させられる。そこで、実行環境をAWS Lambdaに移行することによってこの問題を解決する